### PR TITLE
fixed issue with toJSON not including name property in estimators

### DIFF
--- a/src/RandomForestBase.js
+++ b/src/RandomForestBase.js
@@ -145,7 +145,7 @@ export class RandomForestBase {
             treeOptions: this.treeOptions,
             isClassifier: this.isClassifier,
             seed: this.seed,
-            estimators: this.estimators,
+            estimators: this.estimators.map(est => est.toJSON()),
             useSampleBagging: this.useSampleBagging
         };
     }


### PR DESCRIPTION
Calling the DecisionTreeClassifier.toJSON when creating the json in RandomForestBase.toJSON. 

This, to include the 'name' property in each estimator section of the JSON object.