### PR TITLE
change defaults

### DIFF
--- a/src/RandomForestClassifier.js
+++ b/src/RandomForestClassifier.js
@@ -3,9 +3,9 @@ import { RandomForestBase } from './RandomForestBase';
 const defaultOptions = {
   maxFeatures: 1.0,
   replacement: true,
-  nEstimators: 10,
+  nEstimators: 50,
   seed: 42,
-  useSampleBagging: false,
+  useSampleBagging: true,
 };
 
 /**
@@ -22,9 +22,9 @@ export class RandomForestClassifier extends RandomForestBase {
    *        * if is a float between (0, 1), it takes the percentage of features.
    * @param {boolean} [options.replacement=true] - use replacement over the sample features.
    * @param {number} [options.seed=42] - seed for feature and samples selection, must be a 32-bit integer.
-   * @param {number} [options.nEstimators=10] - number of estimator to use.
+   * @param {number} [options.nEstimators=50] - number of estimator to use.
    * @param {object} [options.treeOptions={}] - options for the tree classifier, see [ml-cart]{@link https://mljs.github.io/decision-tree-cart/}
-   * @param {boolean} [options.useSampleBagging=false] - use bagging over training samples.
+   * @param {boolean} [options.useSampleBagging=true] - use bagging over training samples.
    * @param {object} model - for load purposes.
    */
   constructor(options, model) {

--- a/src/RandomForestRegression.js
+++ b/src/RandomForestRegression.js
@@ -11,11 +11,11 @@ const selectionMethods = {
 const defaultOptions = {
   maxFeatures: 1.0,
   replacement: false,
-  nEstimators: 10,
+  nEstimators: 50,
   treeOptions: {},
   selectionMethod: 'mean',
   seed: 42,
-  useSampleBagging: false,
+  useSampleBagging: true,
 };
 
 /**
@@ -32,10 +32,10 @@ export class RandomForestRegression extends RandomForestBase {
    *        * if is a float between (0, 1), it takes the percentage of features.
    * @param {boolean} [options.replacement=true] - use replacement over the sample features.
    * @param {number} [options.seed=42] - seed for feature and samples selection, must be a 32-bit integer.
-   * @param {number} [options.nEstimators=10] - number of estimator to use.
+   * @param {number} [options.nEstimators=50] - number of estimator to use.
    * @param {object} [options.treeOptions={}] - options for the tree classifier, see [ml-cart]{@link https://mljs.github.io/decision-tree-cart/}
    * @param {string} [options.selectionMethod="mean"] - the way to calculate the prediction from estimators, "mean" and "median" are supported.
-   * @param {boolean} [options.useSampleBagging=false] - use bagging over training samples.
+   * @param {boolean} [options.useSampleBagging=true] - use bagging over training samples.
    * @param {object} model - for load purposes.
    */
   constructor(options, model) {


### PR DESCRIPTION
Using bootstrap sampling to generate a bunch of different trees is the essence of random forests. Having the option (useSampleBagging) to turn it off is uncommon, but defaulting to false is super odd. 

I also increased the number of trees. On R the default is 500, on python i think it is 100. I don't know, why the default here was 10 (perfomance?), but that is usually not enough.