### PR TITLE
Refactor: replace mode() with ml-array-mode 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "ml-array-mean": "^1.1.4",
     "ml-array-median": "^1.1.4",
+    "ml-array-mode": "^1.1.3",
     "ml-cart": "^2.0.2",
     "ml-matrix": "^6.5.3",
     "random-js": "^2.1.0"

--- a/src/RandomForestBase.js
+++ b/src/RandomForestBase.js
@@ -171,6 +171,11 @@ export class RandomForestBase {
     return predictions;
   }
 
+  /**
+   * Predicts the output given the matrix to predict.
+   * @param {Matrix|Array} toPredict
+   * @return {MatrixTransposeView} predictions of estimators
+   */
   predictionValues(toPredict) {
     let predictionValues = new Array(this.nEstimators);
     toPredict = Matrix.checkMatrix(toPredict);
@@ -183,6 +188,7 @@ export class RandomForestBase {
       new WrapperMatrix2D(predictionValues),
     ));
   }
+
   /**
    * Returns the Out-Of-Bag predictions.
    * @return {Array} predictions

--- a/src/RandomForestClassifier.js
+++ b/src/RandomForestClassifier.js
@@ -1,3 +1,5 @@
+import arrayMode from 'ml-array-mode';
+
 import { RandomForestBase } from './RandomForestBase';
 
 const defaultOptions = {
@@ -44,7 +46,7 @@ export class RandomForestClassifier extends RandomForestBase {
    * @return {number} prediction
    */
   selection(values) {
-    return mode(values);
+    return arrayMode(values);
   }
 
   /**
@@ -84,6 +86,7 @@ export class RandomForestClassifier extends RandomForestBase {
       sortedLabels.map((w) => (matrix[v] || {})[w] || 0),
     );
   }
+
   /**
    * Load a Decision tree classifier with the given model.
    * @param {object} model
@@ -123,18 +126,4 @@ export class RandomForestClassifier extends RandomForestBase {
 
     return predictions;
   }
-}
-
-/**
- * Return the most repeated element on the array.
- * @param {Array} arr
- * @return {number} mode
- */
-function mode(arr) {
-  return arr
-    .sort(
-      (a, b) =>
-        arr.filter((v) => v === a).length - arr.filter((v) => v === b).length,
-    )
-    .pop();
 }


### PR DESCRIPTION
Hello maintainers,

Many thanks for your work on this project.

How this PR helps:
- Since `RandomForestRegression` is already using the packages `ml-array-mean` and `ml-array-median`. I think it makes sense to let `RandomForestRegression` import from `ml-array-median` instead of defining its own `mode()` function.
- Adds documentation to `predictionValues()`.
- Other minor changes.

I hope my PR will get accepted.